### PR TITLE
Support spaces around `=` syntax

### DIFF
--- a/envvarProvider.js
+++ b/envvarProvider.js
@@ -38,12 +38,12 @@ const provider = {
                 .split(EOL)
                 // filter out comments
                 .filter(line => !line.trim().startsWith('#'))
-                .forEach(envvarLitteral => envvars.push(envvarLitteral.trim().split('=')));
+                .forEach(envvarLitteral => envvars.push(envvarLitteral.split('=')));
         }
         
         return envvars.map(envvar => {
-            const completion = new vscode.CompletionItem(envvar[0], vscode.CompletionItemKind.Variable);
-            completion.documentation = envvar[1];
+            const completion = new vscode.CompletionItem(envvar[0].trim(), vscode.CompletionItemKind.Variable);
+            completion.documentation = envvar[1].trim();
 
             return completion;
         });


### PR DESCRIPTION
Before, `variable = 'value'` would get parsed with a trailing whitespace after `variable` and a leading whitespace before `'value'`. This PR parses it correctly (trimming the whitespace).