### PR TITLE
Add support for other methods of loading .env files than dotenv

### DIFF
--- a/envvarProvider.js
+++ b/envvarProvider.js
@@ -13,12 +13,6 @@ const findProjectDir = (fileName) => {
     }
 }
 
-const isDotenvInDeps = (projectDir) => {
-    const { dependencies, devDependencies } = require(`${projectDir}/package.json`);
-    return dependencies && (dependencies.dotenv || dependencies.next || dependencies['dotenv-flow'])
-        || devDependencies && (devDependencies.dotenv || devDependencies['dotenv-flow']);
-}
-
 const provider = {
     provideCompletionItems(document, position) {
         console.debug('started providing');
@@ -33,7 +27,7 @@ const provider = {
         const projectDir = findProjectDir(document.fileName);
         let envvars = Object.entries(process.env);
 
-        if (projectDir && isDotenvInDeps(projectDir)) {
+        if (projectDir) {
             const fileContent = fs.readFileSync(`${projectDir}/.env`, { encoding: 'utf8' });
             fileContent
                 .split(EOL)

--- a/envvarProvider.js
+++ b/envvarProvider.js
@@ -15,7 +15,8 @@ const findProjectDir = (fileName) => {
 
 const isDotenvInDeps = (projectDir) => {
     const { dependencies, devDependencies } = require(`${projectDir}/package.json`);
-    return dependencies && (dependencies.dotenv || dependencies.next) || devDependencies && devDependencies.dotenv;
+    return dependencies && (dependencies.dotenv || dependencies.next || dependencies['dotenv-flow'])
+        || devDependencies && (devDependencies.dotenv || devDependencies['dotenv-flow']);
 }
 
 const provider = {


### PR DESCRIPTION
[dotenv-flow](https://www.npmjs.com/package/dotenv-flow) is an alternative to dotenv that adds the ability to have multiple .env* files like .env.development, .env.test and .env.production.

Related to #14 and #2.